### PR TITLE
ディレクティブの書き込み方法の変更

### DIFF
--- a/param.fs
+++ b/param.fs
@@ -634,7 +634,17 @@ namespace Aqualis
                 ()
                 
         ///<summary>プライベート変数リストに変数名を登録</summary>
-        member _.pvreg name = pvlist_<-pvlist_@[name]
+        member _.pvreg name =
+            let rec findname i =
+                if pvlist_.Item(i)<>name then
+                    if (i+1)<pvlist_.Length then
+                        findname (i+1)
+                    else
+                        pvlist_<-pvlist_@[name]
+            if pvlist_.IsEmpty then
+                pvlist_<-pvlist_@[name]
+            else
+                findname 0
 
         ///<summary>プライベート変数リストを初期化</summary>
         member _.clearpv() = pvlist_<-[]
@@ -643,14 +653,34 @@ namespace Aqualis
         member _.switch_parmode (tf:bool) = par_mode<-tf
 
         ///<summary>GPUに転送する変数のリストに変数名を追加</summary>
-        member _.civreg name = copy_in_vlist_<-copy_in_vlist_@[name]
+        member _.civreg name =
+            let rec findname i =
+                if copy_in_vlist_.Item(i)<>name then
+                    if (i+1)<copy_in_vlist_.Length then
+                        findname (i+1)
+                    else
+                        copy_in_vlist_<-copy_in_vlist_@[name]
+            if copy_in_vlist_.IsEmpty then
+                copy_in_vlist_<-copy_in_vlist_@[name]
+            else
+                findname 0
 
         ///<summary>GPUに転送する変数リストから変数を削除</summary>
         member _.rmciv (var:string) =
             copy_in_vlist_<-List.filter(fun s -> s<>var) copy_in_vlist_
 
         ///<summary>ホストに転送する変数のリストに変数名を追加</summary>
-        member _.covreg name = copy_out_vlist_<-copy_out_vlist_@[name]
+        member _.covreg name =
+            let rec findname i =
+                if copy_out_vlist_.Item(i)<>name then
+                    if (i+1)<copy_out_vlist_.Length then
+                        findname (i+1)
+                    else
+                        copy_out_vlist_<-copy_out_vlist_@[name]
+            if copy_out_vlist_.IsEmpty then
+                copy_out_vlist_<-copy_out_vlist_@[name]
+            else
+                findname 0
 
         ///<summary>ホストに転送する変数リストから変数を削除</summary>
         member _.rmcov (var:string) =

--- a/test.fsx
+++ b/test.fsx
@@ -20,55 +20,46 @@ let aperture(xi:num0,eta:num0) code =
 //フレネルキルヒホッフ回折の被積分関数
 let integrand(z:num0,sz:num0,k:num0,r0:num0,r:num0) =
     asm.exp(-asm.uj*k*(r0+r))/(r0*r) * ((-sz)/r0 + z/r)
-
+    
 //積分計算
-let integral (g:num0,z:num0,sx:num0,sy:num0,sz:num0,k:num0,r:num0,h:num2) =
+let integral (g:num0,z:num0,sx:num0,sy:num0,sz:num0,k:num0,r:num0) =
     g <== 0
     let dx = (5.0-(-5.0))/200.0
     let dy = (5.0-(-5.0))/200.0
-    ch.private_ddd <| fun (xi,eta,r0) ->
-        omp.parallelize <| fun () ->
-            iter.range -100 100 <| fun ix ->
-                iter.range -100 100 <| fun iy ->                
-                    xi <== dx * ix
-                    eta <== dy * iy
-                    r0 <== asm.sqrt((xi-sx)*(xi-sx)+(eta-sy)*(eta-sy)+sz*sz)
-                    aperture (xi,eta)
-                      <| fun () ->
+    ch.private_dddz <| fun (xi,eta,r0,h) ->
+        iter.range -100 100 <| fun ix ->
+            iter.range -100 100 <| fun iy ->                
+                xi <== dx * ix
+                eta <== dy * iy
+                h.clear()
+                r0 <== asm.sqrt((xi-sx)*(xi-sx)+(eta-sy)*(eta-sy)+sz*sz)
+                aperture (xi,eta)
+                    <| fun () ->
                         //開口面の中
-                        h[ix+101,iy+101] <== integrand(z,sz,k,r0,r)
-        iter.num 201 <| fun i ->
-            iter.num 201 <| fun j ->
-                g <== g + h[i,j]
+                        h <== integrand(z,sz,k,r0,r)
+                g <== g + h
         g <== g * dx * dy
 
 Compile [F] outputdir projectname fullversion <| fun () ->
     //波長-->1,波数-->k
-    ch.id <| fun (counta,k) ->
-        counta <== 1
+    ch.d <| fun k ->
         k <== 2*asm.pi
         //波源の座標-->(sx,sy,sz)
         ch.ddd <| fun (sx,sy,sz) ->
             sx <== 0
             sy <== 0
             sz <== -2
-            ch.z <| fun g ->
-                ch.z1 (201*201) <| fun f ->
-                    //観測点(x,y,z)
-                    ch.d1 (201*201) <| fun x ->
-                        ch.d1 (201*201) <| fun y ->
-                            ch.dd <| fun (z,r) ->
-                                z <== 2
-                                ch.z2 201 201 <| fun h ->
-                                    iter.range -100 100 <| fun i ->
-                                        iter.range -100 100 <| fun j ->
-                                            //プロットする範囲
-                                            x[counta] <== i*(5 - (-5))/200
-                                            y[counta] <== j*(5 - (-5))/200
-                                            r <== asm.sqrt(x[counta]*x[counta]+y[counta]*y[counta]+z*z)
-                                            integral (g,z,sx,sy,sz,k,r,h)
-                                            f[counta] <== asm.uj/2 * g
-                                            counta <== counta + 1
-                                io.fileOutput [!."test.dat"] <| fun wr ->
-                                    iter.num x.size1 <| fun i ->
-                                        wr [x[i]; y[i]; f[i]]
+            ch.private_zz <| fun (f,g) ->
+                //観測点(x,y,z)
+                ch.private_ddd <| fun (x,y,r) ->
+                    ch.d <| fun z ->
+                        z <== 2
+                        omp.parallelize <| fun () ->
+                            iter.range -100 100 <| fun i ->
+                                iter.range -100 100 <| fun j ->
+                                    //プロットする範囲
+                                    x <== i*(5 - (-5))/200
+                                    y <== j*(5 - (-5))/200
+                                    r <== asm.sqrt(x*x+y*y+z*z)
+                                    integral (g,z,sx,sy,sz,k,r)
+                                    f <== asm.uj/2 * g


### PR DESCRIPTION
・プライベート変数の数が多いとき、ディレクティブを複数行に分けて書き込む仕様に変更しました。
・プライベート変数リストやCPU・GPU間の転送を行う変数リストに同じ変数が重複して登録されてしまう問題を修正しました。